### PR TITLE
Varchar fix on database log

### DIFF
--- a/database/migrations/2025_06_04_132240_fix_award_log_var_char.php
+++ b/database/migrations/2025_06_04_132240_fix_award_log_var_char.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Scheme::table('awards_log', function (Blueprint $table) {
+            $table->text('log')->change();
+            $table->text('data')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Scheme::table('awards_log', function (Blueprint $table) {
+            $table->string('log', 191)->change();
+            $table->string('data', 1024)->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Pushing the fix to follow the general log convention on the length (and also because it would cause issues trying to delete some awards with a long name)