### PR TITLE
fix: migration typo

### DIFF
--- a/database/migrations/2025_06_04_132240_fix_award_log_var_char.php
+++ b/database/migrations/2025_06_04_132240_fix_award_log_var_char.php
@@ -8,7 +8,7 @@ return new class extends Migration {
      * Run the migrations.
      */
     public function up(): void {
-        Scheme::table('awards_log', function (Blueprint $table) {
+        Schema::table('awards_log', function (Blueprint $table) {
             $table->text('log')->change();
             $table->text('data')->nullable()->change();
         });
@@ -18,7 +18,7 @@ return new class extends Migration {
      * Reverse the migrations.
      */
     public function down(): void {
-        Scheme::table('awards_log', function (Blueprint $table) {
+        Schema::table('awards_log', function (Blueprint $table) {
             $table->string('log', 191)->change();
             $table->string('data', 1024)->nullable()->change();
         });


### PR DESCRIPTION
The newest migration to fix the length of award logs typos `Schema` as `Scheme` which will cause an error upon running migrate.